### PR TITLE
Update Cake.Sdk version, enhance build scripts & CI workflows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -334,7 +334,7 @@ __pycache__/
 *.pyc
 
 # Cake - Uncomment if you are using it
-# tools/**
+tools/**
 # !tools/packages.config
 
 # Tabs Studio

--- a/build.cs
+++ b/build.cs
@@ -1,46 +1,116 @@
 #:sdk Cake.Sdk
 #:package Cake.BuildSystems.Module@7.1.0
 
-var target = Argument("target", "Test");
-var configuration = Argument("configuration", "Release");
+var target = Argument("target", "Pack");
 
 //////////////////////////////////////////////////////////////////////
 // TASKS
 //////////////////////////////////////////////////////////////////////
 
+Setup(context =>
+{
+    var configuration = Argument("configuration", "Release");
+
+    InstallTool("dotnet:https://api.nuget.org/v3/index.json?package=GitVersion.Tool&version=6.3.0");
+    var version = GitVersion();
+
+    Information(
+        "Building Version: {0}, Configuration: {1}",
+        version.FullSemVer,
+        configuration);
+
+    return new BuildData(
+        Version: version.FullSemVer,
+        Configuration: configuration,
+        SolutionFile: "./src/Example.sln",
+        ArtifactsDirectory: "./artifacts",
+        MSBuildSettings: new DotNetMSBuildSettings()
+                            .SetVersion(version.FullSemVer)
+                            .SetConfiguration(configuration)
+                            .WithProperty("WarnAsError", "true"));
+});
+
 Task("Clean")
     .WithCriteria(c => HasArgument("rebuild"))
-    .Does(() =>
+    .Does<BuildData>((ctx, data) =>
 {
-    CleanDirectory($"./src/Example/bin/{configuration}");
+    CleanDirectories(data.DirectoriesToClean);
 });
 
 Task("Build")
     .IsDependentOn("Clean")
-    .Does(() =>
+    .Does<BuildData>((ctx, data) =>
 {
-    DotNetBuild("./src/Example.sln", new DotNetBuildSettings
-    {
-        Configuration = configuration,
-    });
+    DotNetBuild(
+        data.SolutionFile.FullPath,
+        new DotNetBuildSettings
+        {
+            MSBuildSettings = data.MSBuildSettings
+        });
 });
 
 Task("Test")
     .IsDependentOn("Build")
-    .Does(() =>
+    .Does<BuildData>((ctx, data) =>
 {
-    DotNetTest("./src/Example.sln", new DotNetTestSettings
-    {
-        Configuration = configuration,
-        NoBuild = true,
-    });
+    DotNetTest(
+        data.SolutionFile.FullPath,
+        new DotNetTestSettings
+        {
+            MSBuildSettings = data.MSBuildSettings,
+            NoRestore = true,
+            NoBuild = true
+        });
 });
 
+Task("Pack")
+    .IsDependentOn("Test")
+    .Does<BuildData>((ctx, data) =>
+{
+    DotNetPack(
+        data.SolutionFile.FullPath,
+        new DotNetPackSettings
+        {
+            MSBuildSettings = data.MSBuildSettings,
+            NoRestore = true,
+            NoBuild = true,
+            OutputDirectory = "./artifacts"
+        });
+});
+
+Task("UploadArtifacts")
+    .IsDependentOn("Pack")
+    .Does<BuildData>((ctx, data) =>
+        GitHubActions.Commands.UploadArtifact(
+            data.ArtifactsDirectory,
+            "ExampleArtifacts"));
+
 Task("GitHubActions")
-    .IsDependentOn("Test");
+    .IsDependentOn("UploadArtifacts");
 
 //////////////////////////////////////////////////////////////////////
 // EXECUTION
 //////////////////////////////////////////////////////////////////////
 
-RunTarget(target); 
+RunTarget(target);
+
+
+//////////////////////////////////////////////////////////////////////
+// Models
+//////////////////////////////////////////////////////////////////////
+
+public record BuildData(
+    string Version,
+    string Configuration,
+    FilePath SolutionFile,
+    DirectoryPath ArtifactsDirectory,
+    DotNetMSBuildSettings MSBuildSettings
+)
+{
+    public DirectoryPath[] DirectoriesToClean { get; init; } =
+        [
+            $"./src/Example/bin/{Configuration}",
+            $"./src/Example/obj/{Configuration}",
+            ArtifactsDirectory
+        ];
+}

--- a/build/BuildData.cs
+++ b/build/BuildData.cs
@@ -1,0 +1,17 @@
+namespace build;
+
+public record BuildData(
+    string Version,
+    string Configuration,
+    FilePath SolutionFile,
+    DirectoryPath ArtifactsDirectory,
+    DotNetMSBuildSettings MSBuildSettings
+)
+{
+    public DirectoryPath[] DirectoriesToClean { get; init; } =
+        [
+            $"./src/Example/bin/{Configuration}",
+            $"./src/Example/obj/{Configuration}",
+            ArtifactsDirectory
+        ];
+}

--- a/build/build.cs
+++ b/build/build.cs
@@ -1,43 +1,94 @@
-var target = Argument("target", "Test");
-var configuration = Argument("configuration", "Release");
+using build;
+
+var target = Argument("target", "Pack");
 
 //////////////////////////////////////////////////////////////////////
 // TASKS
 //////////////////////////////////////////////////////////////////////
 
+Setup(context =>
+{
+    var configuration = Argument("configuration", "Release");
+
+    InstallTool("dotnet:https://api.nuget.org/v3/index.json?package=GitVersion.Tool&version=6.3.0");
+    var version = GitVersion();
+
+    Information(
+        "Building Version: {0}, Configuration: {1}",
+        version.FullSemVer,
+        configuration);
+
+    return new BuildData(
+        Version: version.FullSemVer,
+        Configuration: configuration,
+        SolutionFile: "./src/Example.sln",
+        ArtifactsDirectory: "./artifacts",
+        MSBuildSettings: new DotNetMSBuildSettings()
+                            .SetVersion(version.FullSemVer)
+                            .SetConfiguration(configuration)
+                            .WithProperty("WarnAsError", "true"));
+});
+
 Task("Clean")
     .WithCriteria(c => HasArgument("rebuild"))
-    .Does(() =>
+    .Does<BuildData>((ctx, data) =>
 {
-    CleanDirectory($"./src/Example/bin/{configuration}");
+    CleanDirectories(data.DirectoriesToClean);
 });
 
 Task("Build")
     .IsDependentOn("Clean")
-    .Does(() =>
+    .Does<BuildData>((ctx, data) =>
 {
-    DotNetBuild("./src/Example.sln", new DotNetBuildSettings
-    {
-        Configuration = configuration,
-    });
+    DotNetBuild(
+        data.SolutionFile.FullPath,
+        new DotNetBuildSettings
+        {
+            MSBuildSettings = data.MSBuildSettings
+        });
 });
 
 Task("Test")
     .IsDependentOn("Build")
-    .Does(() =>
+    .Does<BuildData>((ctx, data) =>
 {
-    DotNetTest("./src/Example.sln", new DotNetTestSettings
-    {
-        Configuration = configuration,
-        NoBuild = true,
-    });
+    DotNetTest(
+        data.SolutionFile.FullPath,
+        new DotNetTestSettings
+        {
+            MSBuildSettings = data.MSBuildSettings,
+            NoRestore = true,
+            NoBuild = true
+        });
 });
 
+Task("Pack")
+    .IsDependentOn("Test")
+    .Does<BuildData>((ctx, data) =>
+{
+    DotNetPack(
+        data.SolutionFile.FullPath,
+        new DotNetPackSettings
+        {
+            MSBuildSettings = data.MSBuildSettings,
+            NoRestore = true,
+            NoBuild = true,
+            OutputDirectory = "./artifacts"
+        });
+});
+
+Task("UploadArtifacts")
+    .IsDependentOn("Pack")
+    .Does<BuildData>((ctx, data) =>
+        GitHubActions.Commands.UploadArtifact(
+            data.ArtifactsDirectory,
+            "ExampleArtifacts"));
+
 Task("GitHubActions")
-    .IsDependentOn("Test");
+    .IsDependentOn("UploadArtifacts");
 
 //////////////////////////////////////////////////////////////////////
 // EXECUTION
 //////////////////////////////////////////////////////////////////////
 
-RunTarget(target); 
+RunTarget(target);

--- a/global.json
+++ b/global.json
@@ -3,6 +3,6 @@
     "version": "10.0.100-preview.5.25277.114"
   },
   "msbuild-sdks": {
-    "Cake.Sdk": "5.0.25162.3-alpha"
+    "Cake.Sdk": "5.0.25167.12-alpha"
   }
 }

--- a/src/Example.sln
+++ b/src/Example.sln
@@ -7,6 +7,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Example", "Example\Example.
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Example.Tests", "Example.Tests\Example.Tests.csproj", "{839B9B6E-239D-4E2D-ADAE-99B26EB43DF9}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Build", "Build", "{DEE5DD87-39C1-BF34-B639-A387DCCF972B}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "build", "..\build\build.csproj", "{42E65476-B7D2-47C2-9300-06C2E14FE1EB}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -41,8 +45,23 @@ Global
 		{839B9B6E-239D-4E2D-ADAE-99B26EB43DF9}.Release|x64.Build.0 = Release|Any CPU
 		{839B9B6E-239D-4E2D-ADAE-99B26EB43DF9}.Release|x86.ActiveCfg = Release|Any CPU
 		{839B9B6E-239D-4E2D-ADAE-99B26EB43DF9}.Release|x86.Build.0 = Release|Any CPU
+		{42E65476-B7D2-47C2-9300-06C2E14FE1EB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{42E65476-B7D2-47C2-9300-06C2E14FE1EB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{42E65476-B7D2-47C2-9300-06C2E14FE1EB}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{42E65476-B7D2-47C2-9300-06C2E14FE1EB}.Debug|x64.Build.0 = Debug|Any CPU
+		{42E65476-B7D2-47C2-9300-06C2E14FE1EB}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{42E65476-B7D2-47C2-9300-06C2E14FE1EB}.Debug|x86.Build.0 = Debug|Any CPU
+		{42E65476-B7D2-47C2-9300-06C2E14FE1EB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{42E65476-B7D2-47C2-9300-06C2E14FE1EB}.Release|Any CPU.Build.0 = Release|Any CPU
+		{42E65476-B7D2-47C2-9300-06C2E14FE1EB}.Release|x64.ActiveCfg = Release|Any CPU
+		{42E65476-B7D2-47C2-9300-06C2E14FE1EB}.Release|x64.Build.0 = Release|Any CPU
+		{42E65476-B7D2-47C2-9300-06C2E14FE1EB}.Release|x86.ActiveCfg = Release|Any CPU
+		{42E65476-B7D2-47C2-9300-06C2E14FE1EB}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{42E65476-B7D2-47C2-9300-06C2E14FE1EB} = {DEE5DD87-39C1-BF34-B639-A387DCCF972B}
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
- Update Cake.Sdk version in global.json to 5.0.25167.12-alpha.
- Uncomment tools/** in .gitignore to allow Cake tools.
- Update build.cs and build/build.cs to use a BuildData record for centralized build settings.
- Add GitVersion.Tool integration for versioning.
- Add Pack and UploadArtifacts tasks to build.cs and build/build.cs.
- Update GitHubActions task to depend on UploadArtifacts.
- Add build project to solution and organize under a Build solution folder.